### PR TITLE
feat: support generating SFDIs from DER or PEM certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,3 @@
 [workspace]
 resolver = "2"
-members = [
-    "sep2_client",
-    "sep2_test_server",
-]
-
+members = ["sep2_client", "sep2_test_server"]

--- a/sep2_client/Cargo.toml
+++ b/sep2_client/Cargo.toml
@@ -7,27 +7,41 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/ethanndickson/sep2_client"
-keywords = ["energy","DER","20305","SEP2","IEEE2030"]
+keywords = ["energy", "DER", "20305", "SEP2", "IEEE2030"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.72"
-async-trait = "0.1.72"
-sep2_common = { version = "0.1.0", features = ["edev","time"] }
-hyper = { version = "0.14.26", features = ["http1","client","runtime","tcp","server"] }
+sep2_common = { version = "0.1.0", features = ["edev", "time"] }
+hyper = { version = "0.14.26", features = [
+    "http1",
+    "client",
+    "runtime",
+    "tcp",
+    "server",
+] }
 hyper-openssl = "0.9.2"
-log = "0.4.17"
-openssl = "0.10.52"
-rand = "0.8.5"
-tokio = {version = "1.28.1", features = ["rt","net","macros"] }
+log = "0.4.25"
+openssl = "0.10.70"
+rand = "0.9.0"
+tokio = { version = "1.28.1", features = ["rt", "net", "macros"] }
 tokio-openssl = "0.6.3"
-x509-parser = "0.15.1"
+x509-parser = "0.17.0"
 httpdate = "1.0.3"
-ahash = "0.8.6"
+ahash = "0.8.11"
+sha2 = "0.10.8"
 
 [dev-dependencies]
-sep2_common = { version = "0.1.0", features = ["examples","der","edev","fsa","metering","pubsub","dcap"]  }
+sep2_common = { version = "0.1.0", features = [
+    "examples",
+    "der",
+    "edev",
+    "fsa",
+    "metering",
+    "pubsub",
+    "dcap",
+] }
 sep2_test_server = { path = "../sep2_test_server" }
 typemap_rev = "0.3.0"
 simple_logger = "4.2.0"
@@ -37,17 +51,24 @@ clap = "4.4.7"
 default = []
 event = ["sep2_common/edev", "sep2_common/response"]
 der = ["sep2_common/der", "event"]
-pricing = ["sep2_common/pricing","event"]
-messaging = ["sep2_common/messaging","event"]
-drlc = ["sep2_common/drlc","event"]
-flow_reservation = ["sep2_common/flow_reservation","event"]
+pricing = ["sep2_common/pricing", "event"]
+messaging = ["sep2_common/messaging", "event"]
+drlc = ["sep2_common/drlc", "event"]
+flow_reservation = ["sep2_common/flow_reservation", "event"]
 pubsub = ["sep2_common/pubsub"]
 csip_aus = ["sep2_common/csip_aus"]
-all = ["event","der","pricing","messaging","drlc", "flow_reservation", "pubsub","csip_aus"]
+all = [
+    "event",
+    "der",
+    "pricing",
+    "messaging",
+    "drlc",
+    "flow_reservation",
+    "pubsub",
+    "csip_aus",
+]
 
 [[example]]
 name = "der_client"
 path = "examples/der_client.rs"
-required-features = ["pubsub","der","event"]
-
-
+required-features = ["pubsub", "der", "event"]

--- a/sep2_client/src/client.rs
+++ b/sep2_client/src/client.rs
@@ -469,7 +469,7 @@ impl Client {
     ) -> Result<SEPResponse> {
         log::info!("POST {} to {}", R::name(), abs_path);
         let rsrce = serialize(resource)?;
-        let rsrce_size = rsrce.as_bytes().len();
+        let rsrce_size = rsrce.len();
         let req = Request::builder()
             .method(method)
             .header(CONTENT_TYPE, "application/sep+xml")

--- a/sep2_client/src/device.rs
+++ b/sep2_client/src/device.rs
@@ -40,7 +40,7 @@ pub struct SEDevice {
 }
 
 impl SEDevice {
-    /// Create a new SEDevice representation, using a certificate at the given path to generate the SFDI & LFDI and a bitmap representation of the device's category
+    /// Create a new SEDevice representation, using a DER or PEM certificate at the given path to generate the SFDI & LFDI and a bitmap representation of the device's category
     pub fn new_from_cert(
         cert_path: impl AsRef<Path>,
         device_category: DeviceCategoryType,


### PR DESCRIPTION
Closes #11.

Previously, it was unclear whether the client certificate supplied should be DER or PEM encoded, however the specification requires that the SFDI be generated using the hash of the DER encoded certificate. Since they're relatively common, if a PEM certificate is supplied, we'll first re-encode it in DER before taking the hash.