### PR TITLE
feat: support for custom tls options

### DIFF
--- a/sep2_client/src/client.rs
+++ b/sep2_client/src/client.rs
@@ -26,7 +26,14 @@ use tokio::sync::Mutex;
 
 use crate::{
     time::{current_time_with_offset, SEPTime},
-    tls::{create_client, create_client_tls_cfg, create_http_client, ClientInner},
+    tls::{
+        create_client,
+        create_client_tls_cfg,
+        create_client_tls_cfg_with_options,
+        create_http_client,
+        ClientInner,
+        ClientTlsOptions,
+    },
 };
 
 #[cfg(feature = "event")]
@@ -282,6 +289,30 @@ impl Client {
         tickrate: Option<Duration>,
     ) -> Result<Self> {
         let cfg = create_client_tls_cfg(cert_path, pk_path, rootca_path)?;
+        Self::new_https_with_tls_config(server_addr, cfg, tcp_keepalive, tickrate)
+    }
+
+    /// Construct an IEEE 2030.5 Client instance that uses HTTPS with custom TLS options.
+    pub fn new_https_with_tls_options(
+        server_addr: &str,
+        cert_path: impl AsRef<Path>,
+        pk_path: impl AsRef<Path>,
+        rootca_path: impl AsRef<Path>,
+        tls_options: &ClientTlsOptions,
+        tcp_keepalive: Option<Duration>,
+        tickrate: Option<Duration>,
+    ) -> Result<Self> {
+        let cfg = create_client_tls_cfg_with_options(cert_path, pk_path, rootca_path, tls_options)?;
+        Self::new_https_with_tls_config(server_addr, cfg, tcp_keepalive, tickrate)
+    }
+
+    /// Construct an IEEE 2030.5 Client instance that uses a pre-built TLS configuration.
+    pub fn new_https_with_tls_config(
+        server_addr: &str,
+        cfg: crate::tls::TlsClientConfig,
+        tcp_keepalive: Option<Duration>,
+        tickrate: Option<Duration>,
+    ) -> Result<Self> {
         let out = Client {
             addr: server_addr.to_owned().into(),
             inner: ClientInner::Https(create_client(cfg, tcp_keepalive)),

--- a/sep2_client/src/tls.rs
+++ b/sep2_client/src/tls.rs
@@ -21,6 +21,23 @@ pub(crate) type HTTPSClient = Client<HTTPSConnector, Body>;
 pub(crate) type HTTPClient = Client<HttpConnector, Body>;
 pub(crate) type TlsClientConfig = SslConnectorBuilder;
 
+pub const DEFAULT_TLS_CLIENT_CIPHER_LIST: &str = "ECDHE-ECDSA-AES128-CCM8";
+
+#[derive(Clone, Debug)]
+pub struct ClientTlsOptions {
+    pub cipher_list: String,
+    pub use_certificate_chain_file: bool,
+}
+
+impl Default for ClientTlsOptions {
+    fn default() -> Self {
+        Self {
+            cipher_list: DEFAULT_TLS_CLIENT_CIPHER_LIST.to_owned(),
+            use_certificate_chain_file: false,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum ClientInner {
     Https(HTTPSClient),
@@ -41,11 +58,24 @@ pub(crate) fn create_client_tls_cfg(
     pk_path: impl AsRef<Path>,
     rootca_path: impl AsRef<Path>,
 ) -> Result<TlsClientConfig> {
+    create_client_tls_cfg_with_options(cert_path, pk_path, rootca_path, &ClientTlsOptions::default())
+}
+
+pub(crate) fn create_client_tls_cfg_with_options(
+    cert_path: impl AsRef<Path>,
+    pk_path: impl AsRef<Path>,
+    rootca_path: impl AsRef<Path>,
+    options: &ClientTlsOptions,
+) -> Result<TlsClientConfig> {
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
     log::debug!("Setting CipherSuite");
-    builder.set_cipher_list("ECDHE-ECDSA-AES128-CCM8")?;
+    builder.set_cipher_list(&options.cipher_list)?;
     log::debug!("Loading Certificate File");
-    builder.set_certificate_file(cert_path, SslFiletype::PEM)?;
+    if options.use_certificate_chain_file {
+        builder.set_certificate_chain_file(cert_path)?;
+    } else {
+        builder.set_certificate_file(cert_path, SslFiletype::PEM)?;
+    }
     log::debug!("Loading Private Key File");
     builder.set_private_key_file(pk_path, SslFiletype::PEM)?;
     log::debug!("Loading Certificate Authority File");


### PR DESCRIPTION
This allows to support custom TLS options (only a different cypher list + use_certificate_chain_file).